### PR TITLE
Add docker-compose and initialization for gfz services

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,62 @@
+# Set those values before starting the docker compose.
+#
+# riesgos wps:
+# -----------------------------------------------------------------
+# Set the maximum and minimum memory settings for the riesgos wps
+# application server.
+# Currently we use a setting of 4 GB for the development.
+# Depending on the load of the productive machine you may want to
+# increase this setting.
+riesgosWpsCatalinaOpts=-Xmx4g -Xms4g
+
+# Size of the cache for the riesgos wps.
+# The higher the value, the more data can be keept in the cache to deliver
+# faster results.
+# If you are computing for many different scenarios (where caching would
+# give no benetif) you may want to decrease this value.
+# If you have overall more memory available you can increase it.
+# This cache size is part of the overall memory setting for the wps.
+riesgosWpsMaxCacheSizeMb=1024
+
+# And now some settings for the geoserver.
+# The access base url is one that will be used to create resulting
+# wms or wfs links to the geoserver.
+# It must be accessible from outside of the docker compose setup
+# (from the users browser).
+# You may want to set it the server name on that the docker compose
+# will run.
+riesgosWpsGeoserverAccessBaseUrl=http://localhost:8082/geoserver
+
+# The send base url is different as it is used within the docker compose
+# setting. The wps itself will try to send data to the geoserver.
+# In our base case, the geoserver also runs on the same application server
+# as the wps, so it is safe to set it to the service name within the
+# docker compose file (default: riesgos-wps).
+riesgosWpsGeoserverSendBaseUrl=http://riesgos-wps:8080/geoserver
+
+# The username in the geoserver that we will use to upload files
+# to the geoserver (for wms or wfs output).
+riesgosWpsGeoserverUsername=admin
+
+# The password for that user. You should change it.
+# The variable is used for both: the access for the wps, as well
+# as to set the password in the geoserver itself.
+riesgosWpsGeoserverPassword=geoserver
+
+# This is the hostname that the wps server will use to build
+# urls for reference results. Those must be accessible from outside
+# of the docker compose.
+# We also have the same for port & protocol of the resulting url.
+riesgosWpsAccessServerHost=localhost
+riesgosWpsAccessServerPort=8082
+riesgosWpsAccessServerProtocol=http
+
+# The username and passwords for the tomcat user interface.
+riesgosWpsTomcatUsername=admin
+riesgosWpsTomcatPassword=admin
+
+# The password for the wps user in the riesgos wps admin interface.
+riesgosWpsPassword=wps
+# This is the url that can be used within the docker compose to access
+# the wps.
+riesgosWpsSendBaseUrl=http://riesgos-wps:8080/wps

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ modelprop
 quakeledger
 shakyground
 tsunami-wps
+gfz-command-line-tool-repository/
+styles/

--- a/build.sh
+++ b/build.sh
@@ -261,28 +261,6 @@ function build_sysrel {
     echo "TODO!!"
 }
 
-function prepare_riesgos_wps {
-    # We should put all this in an init container for the startup.
-    docker run -p8080:8080 \
-                -v /var/run/docker.sock:/var/run/docker.sock \
-                --name=wps \
-                -d \
-                -e CATALINA_OPTS=-Xmx12g\ -Xms12g \
-                -e RIESGOS_MAX_CACHE_SIZE_MB=8192 \
-                -e RIESGOS_GEOSERVER_USERNAME=admin \
-                -e RIESGOS_GEOSERVER_PASSWORD=geoserver \
-                -e RIESGOS_GEOSERVER_ACCESS_BASE_URL=http://localhost:8080/geoserver \
-                -e RIESGOS_GEOSERVER_SEND_BASE_URL=http://localhost:8080/geoserver \
-                gfzriesgos/riesgos-wps
-    cd gfz-command-line-tool-repository
-    cd assistance/SLD
-    ./add-style-to-geoserver.sh
-    cd ../..
-    ## @TODO: Update configuration to allow CORS. In assistance/geoserver-web.xml, insert <filter>
-    cd ..
-    docker cp ./configs/* wps:/usr/share/riesgos/json-configurations
-}
-
 function build_all {
     build_riesgos_wps
     build_quakeledger
@@ -293,7 +271,6 @@ function build_all {
     build_deus
     build_tssim
     build_sysrel
-    prepare_riesgos_wps
 }
 
 function main {
@@ -335,8 +312,6 @@ function main {
         build_tssim
     elif [ "$1" == "sysrel" ]; then
         build_sysrel
-    elif [ "$1" == "prepare-riesgos-wps" ]; then
-        prepare_riesgos_wps
     else
         echo "no known command found for: $1"
     fi

--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,7 @@ function misses_image {
 function clean {
     # Ensures that we can restart our script from an completely clean state.
     rm -rf config
+    rm -rf styles
     rm -rf gfz-command-line-tool-repository
     rm -rf quakeledger
     rm -rf shakyground-grid-file
@@ -47,10 +48,11 @@ function clean {
 
 function build_riesgos_wps {
     image="gfzriesgos/riesgos-wps"
+    repo="https://github.com/riesgos/gfz-command-line-tool-repository"
     if misses_image $image; then
             echo "Building $image ... "
             if [ ! -d gfz-command-line-tool-repository ]; then
-                git clone https://github.com/riesgos/gfz-command-line-tool-repository
+                git clone "$repo"
             fi
             cd gfz-command-line-tool-repository
             docker build -t $image:latest -f assistance/Dockerfile .
@@ -58,6 +60,16 @@ function build_riesgos_wps {
     else
             echo "Already exists: $image"
     fi
+    if [ ! -d "styles" ]; then
+        mkdir -p "styles"
+    fi
+    if [ ! -f "styles/shakemap-pga.sld" ]; then
+        if [ ! -f "gfz-command-line-tool-repository/assistance/SLD/shakemap-pga.sld" ]; then
+            git clone "$repo"
+        fi
+        cp gfz-command-line-tool-repository/assistance/SLD/* styles
+    fi
+
 }
 
 function build_quakeledger {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+version: "3.3"
+
+services:
+  riesgos-wps:
+    image: gfzriesgos/riesgos-wps:latest
+    restart: always
+    ports:
+      - "8082:8080"
+    env_file:
+      - .env
+    environment:
+      - CATALINA_OPTS=${riesgosWpsCatalinaOpts}
+      - RIESGOS_MAX_CACHE_SIZE_MB=${riesgosWpsMaxCacheSizeMb}
+      - RIESGOS_GEOSERVER_ACCESS_BASE_URL=${riesgosWpsGeoserverAccessBaseUrl}
+      - RIESGOS_GEOSERVER_SEND_BASE_URL=${riesgosWpsGeoserverSendBaseUrl}
+      - RIESGOS_GEOSERVER_USERNAME=${riesgosWpsGeoserverUsername}
+      - RIESGOS_GEOSERVER_PASSWORD=${riesgosWpsGeoserverPassword}
+    volumes:
+      # We need to pass the docker.sock as the WPS itself needs to run
+      # docker commands
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      # We also want a volume for the riesgos-json-config files.
+      # As it is where the processes are defined.
+      - "./configs:/usr/share/riesgos/json-configurations"
+      # We need the hsqldb in order to handle the internal configuration
+      # of the WPS server settings.
+      - "riesgos-wps-hsqldb-dev:/usr/local/tomcat/webapps/wps/WEB-INF/classes/db/data"
+      # And we need to store the server.xml, as we want to overwrite the
+      # timeout settings.
+      #- "riesgos-wps-server-config:/usr/local/tomcat/conf"
+      - "tomcat-folder:/usr/local/tomcat"
+
+  wps-init:
+    image: python:3.10.5-alpine3.15
+    entrypoint: "/entrypoint.sh"
+    depends_on:
+      - riesgos-wps
+    environment:
+      RIESGOS_GEOSERVER_SEND_BASE_URL: ${riesgosWpsGeoserverSendBaseUrl}
+      RIESGOS_GEOSERVER_PASSWORD: ${riesgosWpsGeoserverPassword}
+      RIESGOS_GEOSERVER_USERNAME: ${riesgosWpsGeoserverUsername}
+      RIESGOS_WPS_ACCESS_SERVER_HOST: ${riesgosWpsAccessServerHost}
+      RIESGOS_WPS_ACCESS_SERVER_PORT: ${riesgosWpsAccessServerPort}
+      RIESGOS_WPS_ACCESS_SERVER_PROTOCOL: ${riesgosWpsAccessServerProtocol}
+      RIESGOS_WPS_PASSWORD: ${riesgosWpsPassword}
+      RIESGOS_WPS_SEND_BASE_URL: ${riesgosWpsSendBaseUrl}
+      RIESGOS_WPS_TOMCAT_USERNAME: ${riesgosWpsTomcatUsername}
+      RIESGOS_WPS_TOMCAT_PASSWORD: ${riesgosWpsTomcatPassword}
+    volumes:
+      - "./wps/init/entrypoint.sh:/entrypoint.sh"
+      - "./wps/init/init_wps.py:/init_wps.py"
+      - "tomcat-folder:/tomcat"
+      - "./styles:/styles"
+    env_file:
+      - .env
+
+volumes:
+  riesgos-wps-hsqldb-dev:
+  tomcat-folder:

--- a/wps/init/entrypoint.sh
+++ b/wps/init/entrypoint.sh
@@ -2,6 +2,5 @@
 
 apk add curl bash
 pip install requests
-python3 -u /init_wps.py
 
-tail -f /dev/null
+python3 -u /init_wps.py

--- a/wps/init/entrypoint.sh
+++ b/wps/init/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+apk add curl bash
+pip install requests
+python3 -u /init_wps.py
+
+tail -f /dev/null

--- a/wps/init/init_wps.py
+++ b/wps/init/init_wps.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+
+import re
+import os
+import time
+import pathlib
+from xml.etree import ElementTree
+import requests
+
+# Helper classes and functions
+class Env:
+    def str(self, key, default=None):
+        return os.environ.get(key, default)
+
+
+class Tasks:
+    def __init__(self):
+        self.tasks = []
+
+    def register(self, f):
+        self.tasks.append(f)
+        return f
+
+    def run(self):
+        for f in self.tasks:
+            f()
+
+
+class Tomcat:
+    def __init__(self, base_path):
+        self.base_path = base_path
+
+    def set_connection_timeout(self, connectionTimeout):
+        filepath = self.base_path / "conf" / "server.xml"
+
+        et = ElementTree.parse(filepath)
+        server = et.getroot()
+        service = server.find("Service")
+        connector = service.find("Connector")
+        connector.attrib["connectionTimeout"] = "180000"
+        et.write(filepath)
+
+    def set_username_and_password(self, username, password):
+        filepath = self.base_path / "conf" / "tomcat-users.xml"
+
+        et = ElementTree.parse(filepath)
+        tomcat_users = et.getroot()
+
+        for existing_user in list(
+            tomcat_users.findall("{http://tomcat.apache.org/xml}user")
+        ):
+            tomcat_users.remove(existing_user)
+
+        new_user = ElementTree.Element("{http://tomcat.apache.org/xml}user")
+        new_user.attrib["username"] = username
+        new_user.attrib["password"] = password
+        new_user.attrib["roles"] = "manager-gui"
+        tomcat_users.append(new_user)
+
+        et.write(filepath)
+
+    def reload_settings(self, app):
+        # According to https://stackoverflow.com/a/32367339
+        # It is enought to touch the web.xml to trigger a
+        # restart of the webapp.
+        filepath = self.base_path / "webapps" / app / "WEB-INF" / "web.xml"
+        os.system(f"touch {filepath}")
+
+
+class WaitMixin:
+    def wait_until_ready(self):
+        ready = False
+        while not ready:
+            try:
+                resp = requests.get(self.base_url)
+                resp.raise_for_status()
+                ready = True
+            except Exception:
+                time.sleep(2)
+
+
+class Wps(WaitMixin):
+    def __init__(self, base_url):
+        self.base_url = base_url
+        self.session = requests.Session()
+
+    def _get_csrf(self, resp):
+        resp_elements = resp.text.split()
+        csrf_idx = [i for i, x in enumerate(resp_elements) if x == 'name="_csrf"'][0]
+        crsf_value_str = resp_elements[csrf_idx + 1]
+        csrf_token = re.search('"(.*?)"', crsf_value_str).groups()[0]
+        return csrf_token
+
+    def login(self, username, password):
+        resp_login_page = self.session.get(f"{self.base_url}/login")
+        resp_login_page.raise_for_status()
+        csrf_token = self._get_csrf(resp_login_page)
+
+        resp_login = self.session.post(
+            f"{self.base_url}/j_spring_security_check",
+            {
+                "username": username,
+                "password": password,
+                "_csrf": csrf_token,
+            },
+        )
+        resp_login.raise_for_status()
+
+    def change_password(self, old_password, new_password):
+        resp_change_page = self.session.get(f"{self.base_url}/change_password")
+        resp_change_page.raise_for_status()
+        csrf_token = self._get_csrf(resp_change_page)
+
+        resp_change = self.session.post(
+            f"{self.base_url}/change_password",
+            {
+                "currentPassword": old_password,
+                "newPassword": new_password,
+                "_csrf": csrf_token,
+            },
+        )
+        resp_change.raise_for_status()
+
+    def post_server(self, protocol, hostname, hostport):
+        resp_server_page = self.session.get(f"{self.base_url}/server")
+        resp_server_page.raise_for_status()
+        csrf_token = self._get_csrf(resp_server_page)
+
+        data = {
+            "protocol": protocol,
+            "hostname": hostname,
+            "hostport": hostport,
+            "computation_timeout": "5",
+            "weppapp_path": "wps",
+            "repo_reload_interval": "0.0",
+            "data_inputs_in_response": "false",
+            "cache_capabilites": "false",
+            "response_url_filter_enabled": "false",
+            "min_pool_size": "10",
+            "max_pool_size": "20",
+            "keep_alive_seconds": "1000",
+            "max_queued_tasks": "100",
+            "max_request_size": "128",
+            "add_process_description_Link_to_process_summary": "true",
+        }
+
+        payload = []
+        for key, value in data.items():
+            payload.append(f"value={value}")
+            payload.append(f"key={key}")
+            payload.append("module=org.n52.wps.webapp.entities.Server")
+        payload = "&".join(payload)
+
+        resp_post = self.session.post(
+            f"{self.base_url}/server",
+            payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                "X-CSRF-TOKEN": csrf_token,
+            },
+        )
+        resp_post.raise_for_status()
+
+
+class Geoserver(WaitMixin):
+    def __init__(self, base_path, base_url):
+        self.base_path = base_path
+        self.base_url = base_url
+
+    def set_username_and_password(self, username, password):
+        filepath = (
+            self.base_path / "data" / "security" / "usergroup" / "default" / "users.xml"
+        )
+
+        et = ElementTree.parse(filepath)
+        user_registry = et.getroot()
+        users = user_registry.find("{http://www.geoserver.org/security/users}users")
+
+        for existing_user in list(
+            users.findall("{http://www.geoserver.org/security/users}user")
+        ):
+            users.remove(existing_user)
+
+        new_user = ElementTree.Element("{http://www.geoserver.org/security/users}user")
+        new_user.attrib["enabled"] = "true"
+        new_user.attrib["name"] = username
+        new_user.attrib["password"] = f"plain:{password}"
+        users.append(new_user)
+
+        et.write(filepath)
+
+    def set_role(self, username, role):
+        filepath = (
+            self.base_path / "data" / "security" / "role" / "default" / "roles.xml"
+        )
+
+        et = ElementTree.parse(filepath)
+        role_registry = et.getroot()
+        user_list = role_registry.find(
+            "{http://www.geoserver.org/security/roles}userList"
+        )
+
+        for existing_user_roles in list(
+            user_list.findall("{http://www.geoserver.org/security/roles}userRoles")
+        ):
+            user_list.remove(existing_user_roles)
+
+        new_user_roles = ElementTree.Element(
+            "{http://www.geoserver.org/security/roles}userRoles"
+        )
+        new_user_roles.attrib["username"] = username
+        new_role_ref = ElementTree.Element("{http://www.geoserver.org/security/roles}roleRef")
+        new_role_ref.attrib["roleID"] = role
+        new_user_roles.append(new_role_ref)
+        user_list.append(new_user_roles)
+
+        et.write(filepath)
+
+
+# Some instances of the classes.
+env = Env()
+tomcat = Tomcat(base_path=pathlib.Path("/tomcat"))
+wps = Wps("http://riesgos-wps:8080/wps")
+geoserver = Geoserver(
+    base_path=pathlib.Path("/tomcat/webapps/geoserver"),
+    base_url=env.str("RIESGOS_WPS_SEND_BASE_URL", default="http://riesgos-wps:8080/geoserver"),
+)
+tasks = Tasks()
+
+
+# And our tasks.
+# The tasks run in the order in which we register them here.
+@tasks.register
+def step_tomcat_username_and_password():
+    """Set the username & password for the tomcat admin interface."""
+    username = env.str("RIESGOS_WPS_TOMCAT_USERNAME")
+    password = env.str("RIESGOS_WPS_TOMCAT_PASSWORD")
+    tomcat.set_username_and_password(username=username, password=password)
+
+
+@tasks.register
+def step_tomcat_connection_timeout():
+    """Set the connection timeout for tomcats server.xml file."""
+    tomcat.set_connection_timeout("180000")
+
+
+@tasks.register
+def step_wps_password():
+    initial_username = "wps"
+    initial_password = "wps"
+    wps.wait_until_ready()
+    try:
+        wps.login(username=initial_username, password=initial_password)
+        new_password = env.str("RIESGOS_WPS_PASSWORD", default="wps")
+        wps.change_password(old_password=initial_password, new_password=new_password)
+    except:
+        print("Problem on setting the wps password - skipping")
+
+
+@tasks.register
+def step_wps_server_settings():
+    initial_username = "wps"
+    password = env.str("RIESGOS_WPS_PASSWORD", default="wps")
+
+    protocol = env.str("RIESGOS_WPS_ACCESS_SERVER_PROTOCOL", default="http")
+    hostname = env.str("RIESGOS_WPS_ACCESS_SERVER_HOST", default="localhost")
+    hostport = env.str("RIESGOS_WPS_ACCESS_SERVER_PORT", default="8082")
+
+    wps.wait_until_ready()
+
+    wps.login(username=initial_username, password=password)
+
+    wps.post_server(protocol=protocol, hostname=hostname, hostport=hostport)
+
+
+@tasks.register
+def step_geoserver_password():
+    username = env.str("RIESGOS_GEOSERVER_USERNAME", default="admin")
+    password = env.str("RIESGOS_GEOSERVER_PASSWORD", default="geoserver")
+    geoserver.set_username_and_password(username=username, password=password)
+    geoserver.set_role(username, role="ADMIN")
+
+
+@tasks.register
+def step_geoserver_upload_styles():
+    username = env.str("RIESGOS_GEOSERVER_USERNAME", default="admin")
+    password = env.str("RIESGOS_GEOSERVER_PASSWORD", default="geoserver")
+
+    scriptname = "/styles/add-style-to-geoserver.sh"
+    content = open(scriptname).read()
+    content_updated = (
+        content.replace("__GEOSERVER_URL__", geoserver.base_url)
+        .replace("__GEOSERVER_PASSWORD__", password)
+        .replace("admin", username)
+    )
+
+    updated_scriptname = "/styles/add-style-to-geoserver-updated.sh"
+    with open(updated_scriptname, "w") as outfile:
+        outfile.write(content_updated)
+
+    os.system(f"chmod +x {updated_scriptname}")
+    geoserver.wait_until_ready()
+
+    os.system(updated_scriptname)
+    os.unlink(updated_scriptname)
+
+
+@tasks.register
+def step_tomcat_reload_settings():
+    apps = ["geoserver", "wps"]
+
+    for app in apps:
+        tomcat.reload_settings(app)
+
+
+if __name__ == "__main__":
+    tasks.run()


### PR DESCRIPTION
This pull request adds:

- a docker compose file with the gfz-command-line-tool riesgos wps
- an .env file with the envirnoment variables that need to be set
- a container to initialize the wps

The intialization:
- updates the connection timeout for the tomcat
- changes the username & password for the tomcat management ui
- changes the password for the wps management ui
- updates the server settings (that are used to create urls for file references later)
- changes the geoserer credentials
- uploads the styles to the geoserver

As we mentioned via mattermost we want to try to handle CORS headers via nginx, so that it can apply to all the containers that we currently need to run.