### PR TITLE
Improve init wps script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,6 @@ services:
       # We also want a volume for the riesgos-json-config files.
       # As it is where the processes are defined.
       - "./configs:/usr/share/riesgos/json-configurations"
-      # We need the hsqldb in order to handle the internal configuration
-      # of the WPS server settings.
-      - "riesgos-wps-hsqldb-dev:/usr/local/tomcat/webapps/wps/WEB-INF/classes/db/data"
-      # And we need to store the server.xml, as we want to overwrite the
-      # timeout settings.
-      #- "riesgos-wps-server-config:/usr/local/tomcat/conf"
       - "tomcat-folder:/usr/local/tomcat"
 
   wps-init:
@@ -55,5 +49,4 @@ services:
       - .env
 
 volumes:
-  riesgos-wps-hsqldb-dev:
   tomcat-folder:

--- a/wps/init/init_wps.py
+++ b/wps/init/init_wps.py
@@ -1,36 +1,89 @@
 #!/usr/bin/env python3
 
-import re
+"""Update passwords, set server settings & upload styles."""
+
+import json
 import os
-import time
 import pathlib
+import re
+import time
 from xml.etree import ElementTree
+
 import requests
+from requests.auth import HTTPBasicAuth
+
 
 # Helper classes and functions
 class Env:
+    """A helper class for easier access of env variables with conversion."""
+
     def str(self, key, default=None):
+        """Return the value for the key as a string."""
         return os.environ.get(key, default)
 
 
-class Tasks:
+class InitWpsData:
+    """
+    Helper to allow access for variables that we want to store.
+
+    Allows reuse in later runs of this script.
+    """
+
     def __init__(self):
+        """Load the data from a file."""
+        data = {}
+        self.filename = pathlib.Path("/init_wps.json")
+        if self.filename.exists():
+            with self.filename.open() as infile:
+                data = json.load(infile)
+        self.data = data
+
+    def get(self, key, default=None):
+        """Return the value for the key or use the default value."""
+        return self.data.get(key, default)
+
+    def put(self, key, value):
+        """Store the value for the key."""
+        self.data[key] = value
+
+    def save(self):
+        """Store the data in a file so that it can be reused."""
+        with self.filename.open("w") as outfile:
+            json.dump(self.data, outfile)
+
+
+class Tasks:
+    """
+    Helper class to collect various tasks & run them later.
+
+    This one here is just linear, so without further dependency
+    management (as Makefiles have it).
+    """
+
+    def __init__(self):
+        """Init with empty task list."""
         self.tasks = []
 
     def register(self, f):
+        """Register a task to be done."""
         self.tasks.append(f)
         return f
 
     def run(self):
+        """Run all the tasks."""
         for f in self.tasks:
             f()
 
 
 class Tomcat:
+    """Helper class to make changes on the tomcat configuration."""
+
     def __init__(self, base_path):
+        """Init the object with the file path of the base directory."""
         self.base_path = base_path
 
     def set_connection_timeout(self, connectionTimeout):
+        """Update the connection timeout."""
         filepath = self.base_path / "conf" / "server.xml"
 
         et = ElementTree.parse(filepath)
@@ -41,6 +94,7 @@ class Tomcat:
         et.write(filepath)
 
     def set_username_and_password(self, username, password):
+        """Update the user for the management ui."""
         filepath = self.base_path / "conf" / "tomcat-users.xml"
 
         et = ElementTree.parse(filepath)
@@ -60,6 +114,7 @@ class Tomcat:
         et.write(filepath)
 
     def reload_settings(self, app):
+        """Reload settings for an app."""
         # According to https://stackoverflow.com/a/32367339
         # It is enought to touch the web.xml to trigger a
         # restart of the webapp.
@@ -68,7 +123,10 @@ class Tomcat:
 
 
 class WaitMixin:
+    """Mixin to be able to wait for a server with an base url to be ready."""
+
     def wait_until_ready(self):
+        """Wait until we get success response codes from the servers base url."""
         ready = False
         while not ready:
             try:
@@ -80,11 +138,15 @@ class WaitMixin:
 
 
 class Wps(WaitMixin):
+    """Helper class to interact with the WPS server."""
+
     def __init__(self, base_url):
+        """Init the object with the base url."""
         self.base_url = base_url
         self.session = requests.Session()
 
     def _get_csrf(self, resp):
+        """Extract the csrf token from the response."""
         resp_elements = resp.text.split()
         csrf_idx = [i for i, x in enumerate(resp_elements) if x == 'name="_csrf"'][0]
         crsf_value_str = resp_elements[csrf_idx + 1]
@@ -92,6 +154,7 @@ class Wps(WaitMixin):
         return csrf_token
 
     def login(self, username, password):
+        """Login into the wps server in the session."""
         resp_login_page = self.session.get(f"{self.base_url}/login")
         resp_login_page.raise_for_status()
         csrf_token = self._get_csrf(resp_login_page)
@@ -107,6 +170,11 @@ class Wps(WaitMixin):
         resp_login.raise_for_status()
 
     def change_password(self, old_password, new_password):
+        """
+        Change the password.
+
+        It is required to be logged in to use this method.
+        """
         resp_change_page = self.session.get(f"{self.base_url}/change_password")
         resp_change_page.raise_for_status()
         csrf_token = self._get_csrf(resp_change_page)
@@ -122,6 +190,11 @@ class Wps(WaitMixin):
         resp_change.raise_for_status()
 
     def post_server(self, protocol, hostname, hostport):
+        """
+        Update the server data of the wps (host, port, etc).
+
+        Required to be logged in.
+        """
         resp_server_page = self.session.get(f"{self.base_url}/server")
         resp_server_page.raise_for_status()
         csrf_token = self._get_csrf(resp_server_page)
@@ -163,11 +236,15 @@ class Wps(WaitMixin):
 
 
 class Geoserver(WaitMixin):
+    """Helper class to interact with the geoserver."""
+
     def __init__(self, base_path, base_url):
+        """Init the object with the base_path on the filesystem and the base url for web access."""
         self.base_path = base_path
         self.base_url = base_url
 
     def set_username_and_password(self, username, password):
+        """Update the username & password."""
         filepath = (
             self.base_path / "data" / "security" / "usergroup" / "default" / "users.xml"
         )
@@ -190,6 +267,7 @@ class Geoserver(WaitMixin):
         et.write(filepath)
 
     def set_role(self, username, role):
+        """Set a role for a user."""
         filepath = (
             self.base_path / "data" / "security" / "role" / "default" / "roles.xml"
         )
@@ -199,7 +277,6 @@ class Geoserver(WaitMixin):
         user_list = role_registry.find(
             "{http://www.geoserver.org/security/roles}userList"
         )
-
         for existing_user_roles in list(
             user_list.findall("{http://www.geoserver.org/security/roles}userRoles")
         ):
@@ -209,21 +286,40 @@ class Geoserver(WaitMixin):
             "{http://www.geoserver.org/security/roles}userRoles"
         )
         new_user_roles.attrib["username"] = username
-        new_role_ref = ElementTree.Element("{http://www.geoserver.org/security/roles}roleRef")
+        new_role_ref = ElementTree.Element(
+            "{http://www.geoserver.org/security/roles}roleRef"
+        )
         new_role_ref.attrib["roleID"] = role
         new_user_roles.append(new_role_ref)
         user_list.append(new_user_roles)
 
         et.write(filepath)
 
+    def wait_until_credentials_are_recognized(self, username, password):
+        """Run a basic request with authentification until the auth worked."""
+        ready = False
+        while not ready:
+            try:
+                resp = requests.get(
+                    f"{self.base_url}/rest/workspaces",
+                    auth=HTTPBasicAuth(username, password),
+                )
+                resp.raise_for_status()
+                ready = True
+            except Exception:
+                time.sleep(2)
+
 
 # Some instances of the classes.
 env = Env()
+init_wps_data = InitWpsData()
 tomcat = Tomcat(base_path=pathlib.Path("/tomcat"))
 wps = Wps("http://riesgos-wps:8080/wps")
 geoserver = Geoserver(
     base_path=pathlib.Path("/tomcat/webapps/geoserver"),
-    base_url=env.str("RIESGOS_GEOSERVER_SEND_BASE_URL", default="http://riesgos-wps:8080/geoserver"),
+    base_url=env.str(
+        "RIESGOS_GEOSERVER_SEND_BASE_URL", default="http://riesgos-wps:8080/geoserver"
+    ),
 )
 tasks = Tasks()
 
@@ -246,19 +342,26 @@ def step_tomcat_connection_timeout():
 
 @tasks.register
 def step_wps_password():
+    """Update the wps password."""
     initial_username = "wps"
-    initial_password = "wps"
+    # We store the last password in a file, so that we can read it from
+    # there in case we run multiple docker-compose up calls.
+    # This way we can get the latest password that was used.
+    initial_password = init_wps_data.get("RIESGOS_WPS_PASSWORD", default="wps")
+
     wps.wait_until_ready()
     try:
         wps.login(username=initial_username, password=initial_password)
         new_password = env.str("RIESGOS_WPS_PASSWORD", default="wps")
         wps.change_password(old_password=initial_password, new_password=new_password)
-    except:
+        init_wps_data.put("RIESGOS_WPS_PASSWORD", new_password)
+    except Exception:
         print("Problem on setting the wps password - skipping")
 
 
 @tasks.register
 def step_wps_server_settings():
+    """Update the wps server settings."""
     initial_username = "wps"
     password = env.str("RIESGOS_WPS_PASSWORD", default="wps")
 
@@ -275,6 +378,7 @@ def step_wps_server_settings():
 
 @tasks.register
 def step_geoserver_password():
+    """Update the geoserver password."""
     username = env.str("RIESGOS_GEOSERVER_USERNAME", default="admin")
     password = env.str("RIESGOS_GEOSERVER_PASSWORD", default="geoserver")
     geoserver.set_username_and_password(username=username, password=password)
@@ -282,7 +386,17 @@ def step_geoserver_password():
 
 
 @tasks.register
+def step_tomcat_reload_settings():
+    """Reload the tomcat apps."""
+    apps = ["geoserver", "wps"]
+
+    for app in apps:
+        tomcat.reload_settings(app)
+
+
+@tasks.register
 def step_geoserver_upload_styles():
+    """Upload the styles to the geoserver."""
     username = env.str("RIESGOS_GEOSERVER_USERNAME", default="admin")
     password = env.str("RIESGOS_GEOSERVER_PASSWORD", default="geoserver")
 
@@ -300,17 +414,20 @@ def step_geoserver_upload_styles():
 
     os.system(f"chmod +x {updated_scriptname}")
     geoserver.wait_until_ready()
+    # it is still the problem that the geoserver seem to need some
+    # time uniil it realized that there is a changed password.
+    # (Even after the reload by the tomcat.)
+    # So we wait until our geoserver responds with our current credentials.
+    geoserver.wait_until_credentials_are_recognized(username, password)
 
     os.system(updated_scriptname)
     os.unlink(updated_scriptname)
 
 
 @tasks.register
-def step_tomcat_reload_settings():
-    apps = ["geoserver", "wps"]
-
-    for app in apps:
-        tomcat.reload_settings(app)
+def step_store_data():
+    """Store the data that we collected while doing the init work."""
+    init_wps_data.save()
 
 
 if __name__ == "__main__":

--- a/wps/init/init_wps.py
+++ b/wps/init/init_wps.py
@@ -223,7 +223,7 @@ tomcat = Tomcat(base_path=pathlib.Path("/tomcat"))
 wps = Wps("http://riesgos-wps:8080/wps")
 geoserver = Geoserver(
     base_path=pathlib.Path("/tomcat/webapps/geoserver"),
-    base_url=env.str("RIESGOS_WPS_SEND_BASE_URL", default="http://riesgos-wps:8080/geoserver"),
+    base_url=env.str("RIESGOS_GEOSERVER_SEND_BASE_URL", default="http://riesgos-wps:8080/geoserver"),
 )
 tasks = Tasks()
 


### PR DESCRIPTION
**Still work-in-progress**

- use the correct env variable for the base url of the geoserver (tried to send to the wps before that change)
- remove the volume for the hsql data for the wps config (should be set via env variables & the init script instead).
- wait until the geoserver accepts the requests with the updated password (in case there is a password change)
- add handling to be able to update the wps password without docker-compose down (stores the password for the wps within the container)