### PR TITLE
Store geoserver styles via filesystem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
     depends_on:
       - riesgos-wps
     environment:
-      RIESGOS_GEOSERVER_SEND_BASE_URL: ${riesgosWpsGeoserverSendBaseUrl}
       RIESGOS_GEOSERVER_PASSWORD: ${riesgosWpsGeoserverPassword}
       RIESGOS_GEOSERVER_USERNAME: ${riesgosWpsGeoserverUsername}
       RIESGOS_WPS_ACCESS_SERVER_HOST: ${riesgosWpsAccessServerHost}


### PR DESCRIPTION
The change here makes sure that we set the geoserver styles using the file-system.
This is the less error-prone-version that can be used with the tomcat internal geoserver.