### PR TITLE
Fix shakyground grid image name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -125,7 +125,7 @@ function build_quakeledger {
 function build_shakyground_grid {
     # We reuse this new image later as the base image for shakyground.
     # So that all the grid files are already there.
-    image="gfzriesgos/skakyground-grid-file"
+    image="gfzriesgos/shakyground-grid-file"
     repo="https://github.com/gfzriesgos/shakyground-grid-file"
     if misses_image $image; then
         if [ ! -d shakyground-grid-file ]; then
@@ -150,7 +150,7 @@ function build_shakyground {
             cd shakyground
             # Replace the FROM entry in the dockerfile
             # so that we use our latest shakyground-grid-file image
-            sed -i -e 's/FROM gfzriesgos\/shakyground-grid-file:20211011/FROM gfzriesgos\/skakyground-grid-file:latest/' ./metadata/Dockerfile
+            sed -i -e 's/FROM gfzriesgos\/shakyground-grid-file:20211011/FROM gfzriesgos\/shakyground-grid-file:latest/' ./metadata/Dockerfile
             docker image build --tag $image:latest --file ./metadata/Dockerfile .
             cd $SCRIPT_DIR
     else


### PR DESCRIPTION
I renamed the image for the shayground-grid-file so that it would also be possible to use the image pulled from dockerhub