### PR TITLE
Frontend behind proxy

### DIFF
--- a/.env
+++ b/.env
@@ -82,9 +82,6 @@ sourceEmail = info@riesgos-containerized.com
 # How often should the monitor test the webservices?
 testServiceEveryMinutes = 120
 
-# Is your frontend only available at a certain path?
-frontendSubPath = /
-compareFrontendSubPath = /
 
 # List of url's of wps'es for different processes.
 # The backend will attempt to access those processes via those urls.

--- a/.env
+++ b/.env
@@ -69,9 +69,7 @@ riesgosWpsSendBaseUrl=http://riesgos-wps:8080/wps
 # This is the url under which the frontend will attempt 
 # to contact the backend. Must be accessible from outside of 
 # the docker-network (i.e. from the user's browser)
-backendUrl = http://<host-ip-address>
-# Under which port should your backend be available? 
-backendPort = 8002
+backendUrl = http://<host-ip-address>/backend
 # How long should the backend keep its cache
 maxStoreLifeTimeMinutes = 1440
 

--- a/build.sh
+++ b/build.sh
@@ -339,7 +339,7 @@ function build_frontend {
         echo "Already exists: frontend"
     else
         if [ ! -d "dlr-riesgos-frontend" ]; then
-            git clone https://github.com/riesgos/dlr-riesgos-frontend # --branch=2.0.6-main <-- once we have a stable tag
+            git clone https://github.com/riesgos/dlr-riesgos-frontend --branch=buildall # --branch=2.0.6-main <-- once we have a stable tag
         fi
         sleep 1
         if [ ! -d ./dlr-riesgos-frontend ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,13 +69,11 @@ services:
 
   backend:
     image: dlrriesgos/backend
-    ports:
-      - ${backendPort}:${backendPort}
     volumes:
       - logs:/backend/data/logs
       - store:/backend/data/store
     environment:
-      port: ${backendPort}
+      port: 80
       maxStoreLifeTimeMinutes: ${maxStoreLifeTimeMinutes}
       sendMailTo: ${sendMailTo}
       sourceEmail: ${sourceEmail}
@@ -95,23 +93,17 @@ services:
     image: dlrriesgos/frontend
     depends_on:
       - backend
-    ports:
-      - 8000:80
     environment:
-      subPath: ${frontendSubPath}
+      subPath: "/frontend/"
       backendUrl: ${backendUrl}
-      backendPort: ${backendPort}
 
   compare-frontend:
     image: dlrriesgos/compare-frontend
     depends_on:
       - backend
-    ports:
-      - 8001:80
     environment:
-      subPath: ${compareFrontendSubPath}
+      subPath: "/light/"
       backendUrl: ${backendUrl}
-      backendPort: ${backendPort}
       allowedScenarios: '["PeruShort"]'
 
   tsunawps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
     environment:
       GEOSERVER_DATA_DIR: '/var/www/riesgos/data'
       GEOWEBCACHE_CACHE_DIR: '/var/www/riesgos/data/gwc'
-      RECREATE_DATADIR: false
+      RECREATE_DATADIR: "false"
       GEOSERVER_ADMIN_USER: ${riesgosWpsGeoserverUsername}
       GEOSERVER_ADMIN_PASSWORD: ${riesgosWpsGeoserverPassword}
 

--- a/reverse_proxy/default.conf
+++ b/reverse_proxy/default.conf
@@ -27,6 +27,44 @@ server {
     gzip_comp_level 9;
 
 
+    location /frontend/ {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Expose-Headers' '*';
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        proxy_pass http://frontend/;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    
+    location /light/ {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Expose-Headers' '*';
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        proxy_pass http://compare-frontend/;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /backend/ {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Expose-Headers' '*';
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        proxy_pass http://backend/;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    
 
     location /wps {
         proxy_connect_timeout 300;


### PR DESCRIPTION
All services in architecture so far communicate via the reverse-proxy ... except for the frontend-containers.
This has now been mitigated. 

Each frontend container is behind its own proxy-route (/frontend, /light, and /backend, respectively).
CORS settings have been applied for all routes. 

The frontend-container configuration has changed, too: there is no longer a parameter `backendUrl` and `backendPort`. Only backendUrl is being used now, which may contain a sub-path, too.